### PR TITLE
新規登録のルーティングエラー対処

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -4,7 +4,7 @@
 // that code so it'll be compiled.
 
 require("@rails/ujs").start()
-require("turbolinks").start()
+// require("turbolinks").start()
 require("@rails/activestorage").start()
 require("channels")
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'blogs/index'
   devise_for :users
   root to: "homes#index"
   resources :customers do
@@ -9,5 +8,5 @@ Rails.application.routes.draw do
       get :aggregate_search
     end
   end 
-  resources :blogs
+  get 'blogs/index'
 end


### PR DESCRIPTION
# WHAT
新規登録失敗後のリロード時、ルーティングエラー対処

# WHY
リロードした時のルーティングエラーを解消するため